### PR TITLE
[#9] 페이지 반응형 적용

### DIFF
--- a/src/app/_components/_filter/FilterTable.module.scss
+++ b/src/app/_components/_filter/FilterTable.module.scss
@@ -5,7 +5,7 @@
   display: flex;
   overflow: hidden;
   width: 100%;
-  height: 283px;
+  min-height: 283px;
   border: 1px solid $gray-2;
   flex-direction: column;
   border-radius: 10px;

--- a/src/app/_components/_ui/Chip.module.scss
+++ b/src/app/_components/_ui/Chip.module.scss
@@ -6,10 +6,11 @@
   align-items: center;
   justify-content: center;
   height: 30px;
+  margin: 8px;
   padding: 4px 12px;
   border: none;
-  border-radius: 20px;
   font-size: $font-2;
+  border-radius: 20px;
   background-color: $gray-2;
   cursor: pointer;
 

--- a/src/app/_components/_ui/CourseCard.module.scss
+++ b/src/app/_components/_ui/CourseCard.module.scss
@@ -11,6 +11,11 @@
   border-radius: 8px;
   background-color: white;
 
+  // 1280px 미만
+  @media (max-width: 1279px) {
+    flex: 0 0 calc((100% - (16px * 2)) / 3);
+  }
+
   .content {
     padding: 28px 24px 0;
 

--- a/src/app/_components/_ui/SingleCategory.module.scss
+++ b/src/app/_components/_ui/SingleCategory.module.scss
@@ -5,7 +5,7 @@
   background-color: $white;
   display: flex;
   width: 100%;
-  height: 46px;
+  min-height: 46px;
   gap: 30px;
 
   .left {
@@ -18,8 +18,8 @@
 
   .right {
     display: flex;
-    gap: 10px;
     align-items: center;
     flex: 1;
+    flex-wrap: wrap;
   }
 }

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -11,5 +11,5 @@
 }
 
 .content {
-  width: $content-width;
+  max-width: $content-width;
 }


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 요구사항에 기재된 내용과 실제 엘리스 페이지에 사용중인 내용들을 참고해서 반응형을 적용합니다.
   - 스크린과 컨테이너 사이에 24px 의 padding 적용
   - 스크린의 크기가 1280px 일 경우부터는 레이아웃의 크기가 1280px 로 중앙정렬 되게 고정
   - 스크린의 크기가 1280px 미만일 때는 레이아웃이 스크린 전체의 width를 차지
   - 스크린의 크기가 1280px 미만일 때 CourseCard 갯수 변경 및 최대 너비 차지
   - 스크린 너비에 따른 Chip 버튼 레이아웃 조정
   
- #9 

<br/>

### 📷 스크린 샷 (선택)

![image](https://github.com/minh0518/elice-Frontend-PA/assets/78631876/298dec23-afc3-437b-bc2c-c237c850d96b)


<br/>

### 🗣 리뷰어한테 할 말 (선택)

<br/>


### 🧪 테스트 범위 (선택)
