### PR TITLE
[#19] 에러핸들링 구현 

### DIFF
--- a/src/app/[...path]/page.module.scss
+++ b/src/app/[...path]/page.module.scss
@@ -1,0 +1,22 @@
+@import '@/styles/globals';
+@import '@/styles/mixins';
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 40px;
+  width: 100dvw;
+  height: 100dvh;
+  background-color: $gray-2;
+
+  a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100px;
+    height: 50px;
+    font-size: 20px;
+  }
+}

--- a/src/app/[...path]/page.tsx
+++ b/src/app/[...path]/page.tsx
@@ -1,0 +1,14 @@
+import { ERROR_MESSAGE } from '@/config/const';
+import styles from './page.module.scss';
+import Link from 'next/link';
+
+const page = () => {
+  return (
+    <div className={styles.container}>
+      <h1>{ERROR_MESSAGE.NOT_FOUND}</h1>
+      <Link href={'/'}>홈</Link>
+    </div>
+  );
+};
+
+export default page;

--- a/src/app/_hooks/useFetchData.ts
+++ b/src/app/_hooks/useFetchData.ts
@@ -1,4 +1,5 @@
 import { ERROR_MESSAGE, GC_TIME, STALE_TIME } from '@/config/const';
+import { filteredDataApi } from '@/service/service';
 import { OrgCourseListResponse } from '@/types/const';
 import { useQuery } from '@tanstack/react-query';
 import { v4 as uuidv4 } from 'uuid';
@@ -13,27 +14,28 @@ export const useFetchData = (
   const { data } = useQuery<OrgCourseListResponse>({
     queryKey: ['selected', searchWord, mappedKey, offset, count],
     queryFn: async () => {
-      const response = await fetch(
-        `http://localhost:3000/api/get/list?encodeUrl=${encodeUrl}&offset=${offset}&count=${count}`,
-        {
-          method: 'GET',
-          cache: 'no-store',
-        },
-      );
-      if (response.ok) {
-        const jsonData: OrgCourseListResponse = await response.json();
-        const coursesWithId = jsonData.courses.map((course) => ({
-          ...course,
-          id: uuidv4(),
-        }));
+      return await filteredDataApi.getFilteredData(encodeUrl, offset, count);
+      // const response = await fetch(
+      //   `http://localhost:3000/api/get/list?encodeUrl=${encodeUrl}&offset=${offset}&count=${count}`,
+      //   {
+      //     method: 'GET',
+      //     cache: 'no-store',
+      //   },
+      // );
+      // if (response.ok) {
+      //   const jsonData: OrgCourseListResponse = await response.json();
+      //   const coursesWithId = jsonData.courses.map((course) => ({
+      //     ...course,
+      //     id: uuidv4(),
+      //   }));
 
-        return {
-          ...jsonData,
-          courses: coursesWithId,
-        };
-      }
-      const errorText = await response.text();
-      throw new Error(errorText || ERROR_MESSAGE.OHTER);
+      //   return {
+      //     ...jsonData,
+      //     courses: coursesWithId,
+      //   };
+      // }
+      // const errorText = await response.text();
+      // throw new Error(errorText || ERROR_MESSAGE.OHTER);
     },
     staleTime: STALE_TIME,
     gcTime: GC_TIME,

--- a/src/app/_hooks/useFetchData.ts
+++ b/src/app/_hooks/useFetchData.ts
@@ -1,4 +1,4 @@
-import { GC_TIME, STALE_TIME } from '@/config/const';
+import { ERROR_MESSAGE, GC_TIME, STALE_TIME } from '@/config/const';
 import { OrgCourseListResponse } from '@/types/const';
 import { useQuery } from '@tanstack/react-query';
 import { v4 as uuidv4 } from 'uuid';
@@ -20,18 +20,20 @@ export const useFetchData = (
           cache: 'no-store',
         },
       );
+      if (response.ok) {
+        const jsonData: OrgCourseListResponse = await response.json();
+        const coursesWithId = jsonData.courses.map((course) => ({
+          ...course,
+          id: uuidv4(),
+        }));
 
-      const jsonData: OrgCourseListResponse = await response.json();
-
-      const coursesWithId = jsonData.courses.map((course) => ({
-        ...course,
-        id: uuidv4(),
-      }));
-
-      return {
-        ...jsonData,
-        courses: coursesWithId,
-      };
+        return {
+          ...jsonData,
+          courses: coursesWithId,
+        };
+      }
+      const errorText = await response.text();
+      throw new Error(errorText || ERROR_MESSAGE.OHTER);
     },
     staleTime: STALE_TIME,
     gcTime: GC_TIME,

--- a/src/app/api/get/list/route.ts
+++ b/src/app/api/get/list/route.ts
@@ -1,3 +1,4 @@
+import { ERROR_MESSAGE } from '@/config/const';
 import { OrgCourseListResponse } from '@/types/const';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -8,9 +9,10 @@ export async function GET(request: NextRequest) {
   const offset = request.nextUrl.searchParams.get('offset');
   const count = request.nextUrl.searchParams.get('count');
 
-  if (encodeUrl) {
+  if (encodeUrl && offset && count) {
     const fetchResponse = await fetch(
       `${ELICE_SERVICE_BASE_URL}/?filter_conditions=${encodeURIComponent(encodeUrl)}&sort_by=created_datetime.desc&offset=${offset}&count=${count}`,
+      // `https://api-rest.elice.io/org/academy/course/list/`,
       {
         method: 'GET',
         cache: 'no-store',
@@ -19,33 +21,37 @@ export async function GET(request: NextRequest) {
 
     const data = await fetchResponse.json();
 
-    const transformedData: OrgCourseListResponse = {
-      courseCount: data.course_count,
-      courses: data.courses.map((course: any) => ({
-        courseType: course.course_type,
-        tags: course.tags,
-        title: course.title,
-        shortDescriptioin: course.short_description,
-        classType: course.class_type,
-        logoFileUrl: course.logo_file_url,
-        enrolledRolePeriod: course.enrolled_role_period,
-        enrolledRoleBeginDatetime: course.enroll_begin_datetime,
-        enrolledRoleEndDatetime: course.enroll_end_datetime,
-        beginDatetime: course.begin_datetime,
-        endDatetime: course.end_datetime,
-        isDiscounted: course.is_discounted,
-        discountedPrice: course.discounted_price,
-        discountedPriceUsd: course.discounted_price_usd,
-        discountRate: course.discount_rate,
-        price: course.price,
-        priceUsd: course.price_usd,
-        enrollType: course.enroll_type,
-        isFree: course.is_free,
-      })),
-    };
-
-    return new NextResponse(JSON.stringify(transformedData), { status: 200 });
+    // 필요한 데이터만 매핑
+    try {
+      const extractedData: OrgCourseListResponse = {
+        courseCount: data.course_count,
+        courses: data.courses.map((course: any) => ({
+          courseType: course.course_type,
+          tags: course.tags,
+          title: course.title,
+          shortDescriptioin: course.short_description,
+          classType: course.class_type,
+          logoFileUrl: course.logo_file_url,
+          enrolledRolePeriod: course.enrolled_role_period,
+          enrolledRoleBeginDatetime: course.enroll_begin_datetime,
+          enrolledRoleEndDatetime: course.enroll_end_datetime,
+          beginDatetime: course.begin_datetime,
+          endDatetime: course.end_datetime,
+          isDiscounted: course.is_discounted,
+          discountedPrice: course.discounted_price,
+          discountedPriceUsd: course.discounted_price_usd,
+          discountRate: course.discount_rate,
+          price: course.price,
+          priceUsd: course.price_usd,
+          enrollType: course.enroll_type,
+          isFree: course.is_free,
+        })),
+      };
+      return new NextResponse(JSON.stringify(extractedData), { status: 200 });
+    } catch (e) {
+      return new NextResponse(ERROR_MESSAGE.WRONG_FETCH, { status: 400 });
+    }
   }
 
-  return new NextResponse('데이터를 불러오는 도중 에러가 발생했습니다', { status: 500 });
+  return new NextResponse(ERROR_MESSAGE.WRONG_URL, { status: 400 });
 }

--- a/src/app/error.module.scss
+++ b/src/app/error.module.scss
@@ -1,0 +1,19 @@
+@import '@/styles/globals';
+@import '@/styles/mixins';
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 40px;
+  width: 100dvw;
+  height: 100dvh;
+  background-color: $gray-2;
+
+  button {
+    width: 100px;
+    height: 50px;
+    font-size: 20px;
+  }
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { useEffect } from 'react';
+import styles from './error.module.scss';
+import { useRouter } from 'next/navigation';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const router = useRouter();
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={styles.container}>
+      <h1>{error.message}</h1>
+      <button onClick={() => (window.location.href = '/')}>재시도하기</button>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,9 +6,8 @@ import { getFilterCondition } from './_utils/filter';
 import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
 import { generateQueryKey } from './_utils/generateQueryKey';
 import RQProvider from './_components/RQProvider';
-import { OrgCourseListResponse } from '@/types/const';
-import { v4 as uuidv4 } from 'uuid';
-import { ERROR_MESSAGE, PAGE_CONTENT_LENGTH, START_OFFSET } from '@/config/const';
+import { PAGE_CONTENT_LENGTH, START_OFFSET } from '@/config/const';
+import { filteredDataApi } from '@/service/service';
 
 export type FilterProps = {
   searchParams: {
@@ -32,29 +31,7 @@ export default async function Home({ searchParams }: FilterProps) {
   await queryClient.fetchQuery({
     queryKey: ['selected', searchWord || null, mappedKey, START_OFFSET, PAGE_CONTENT_LENGTH],
     queryFn: async () => {
-      const response = await fetch(
-        `http://localhost:3000/api/get/list?encodeUrl=${encodeUrl}&offset=${START_OFFSET}&count=${PAGE_CONTENT_LENGTH}`,
-        {
-          method: 'GET',
-          cache: 'no-store',
-        },
-      );
-
-      if (response.ok) {
-        const jsonData: OrgCourseListResponse = await response.json();
-        const coursesWithId = jsonData.courses.map((course) => ({
-          ...course,
-          id: uuidv4(),
-        }));
-
-        return {
-          ...jsonData,
-          courses: coursesWithId,
-        };
-      }
-
-      const errorText = await response.text();
-      throw new Error(errorText || ERROR_MESSAGE.OHTER);
+      return await filteredDataApi.getFilteredData(encodeUrl, START_OFFSET, PAGE_CONTENT_LENGTH);
     },
   });
   const dehydratedState = dehydrate(queryClient);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { generateQueryKey } from './_utils/generateQueryKey';
 import RQProvider from './_components/RQProvider';
 import { OrgCourseListResponse } from '@/types/const';
 import { v4 as uuidv4 } from 'uuid';
-import { PAGE_CONTENT_LENGTH, START_OFFSET } from '@/config/const';
+import { ERROR_MESSAGE, PAGE_CONTENT_LENGTH, START_OFFSET } from '@/config/const';
 
 export type FilterProps = {
   searchParams: {
@@ -39,16 +39,22 @@ export default async function Home({ searchParams }: FilterProps) {
           cache: 'no-store',
         },
       );
-      const jsonData: OrgCourseListResponse = await response.json();
-      const coursesWithId = jsonData.courses.map((course) => ({
-        ...course,
-        id: uuidv4(),
-      }));
 
-      return {
-        ...jsonData,
-        courses: coursesWithId,
-      };
+      if (response.ok) {
+        const jsonData: OrgCourseListResponse = await response.json();
+        const coursesWithId = jsonData.courses.map((course) => ({
+          ...course,
+          id: uuidv4(),
+        }));
+
+        return {
+          ...jsonData,
+          courses: coursesWithId,
+        };
+      }
+
+      const errorText = await response.text();
+      throw new Error(errorText || ERROR_MESSAGE.OHTER);
     },
   });
   const dehydratedState = dehydrate(queryClient);

--- a/src/config/const.ts
+++ b/src/config/const.ts
@@ -78,9 +78,18 @@ export const FILTER_CATEGORY = [
   },
 ] as const;
 
+/** pagination */
 export const START_OFFSET = 0;
 export const PAGE_CONTENT_LENGTH = 20 as const;
 export const PAGINATION_REST_BUTTON_LENGTH = 4 as const;
 
+/** Tanstack-query */
 export const STALE_TIME = 1000 * 60 * 60 * 24;
 export const GC_TIME = 1000 * 60 * 5;
+
+/** errorMessage */
+export const ERROR_MESSAGE = {
+  WRONG_FETCH: '데이터를 불러오는 도중 문제가 발생했습니다.',
+  WRONG_URL: 'URL정보를 확인해 주세요.',
+  OHTER: '문제가 발생했습니다.',
+};

--- a/src/config/const.ts
+++ b/src/config/const.ts
@@ -91,5 +91,17 @@ export const GC_TIME = 1000 * 60 * 5;
 export const ERROR_MESSAGE = {
   WRONG_FETCH: '데이터를 불러오는 도중 문제가 발생했습니다.',
   WRONG_URL: 'URL정보를 확인해 주세요.',
+  WRONG_FILTER_QUERY: '필터링 URL이 잘못됐습니다.',
+  NOT_FOUND: 'URL이 존재하지 않습니다.',
   OHTER: '문제가 발생했습니다.',
-};
+} as const;
+
+export const INDEX_INFO = {
+  keyword: 0,
+  courseType: 7,
+  format: 6,
+  category: 1,
+  level: 5,
+  programmingLanguage: 4,
+  price: 3,
+} as const;

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -1,0 +1,29 @@
+import { v4 as uuidv4 } from 'uuid';
+import { OrgCourseListResponse } from '@/types/const';
+import { ERROR_MESSAGE } from '@/config/const';
+
+export const filteredDataApi = {
+  getFilteredData: async (encodeUrl: string, offset: number, count: number) => {
+    const response = await fetch(
+      `http://localhost:3000/api/get/list?encodeUrl=${encodeUrl}&offset=${offset}&count=${count}`,
+      {
+        method: 'GET',
+        cache: 'no-store',
+      },
+    );
+    if (response.ok) {
+      const jsonData: OrgCourseListResponse = await response.json();
+      const coursesWithId = jsonData.courses.map((course) => ({
+        ...course,
+        id: uuidv4(),
+      }));
+
+      return {
+        ...jsonData,
+        courses: coursesWithId,
+      };
+    }
+    const errorText = await response.text();
+    throw new Error(errorText || ERROR_MESSAGE.OHTER);
+  },
+};


### PR DESCRIPTION
### 💁‍♂️ PR 개요


<br />
<br />

- #19 



<br />
<br />

### 에러 핸들링

<br />

> **이번 과제에서 사용한 에러 핸들링은 Next.js의 Error Boundary인 `error.tsx`를 사용했습니다.**

<br />

**`error.tsx`를 사용한 이유는 다음과 같습니다.**

- 각 컴포넌트에서 에러가 발생했을 때, 특정 위치마다 에러를 처리하는 것이 아니라

- 상위 컨텍스트인 `error.tsx`로 모든 에러를 던진 다음 이 곳에서 일괄처리를 하기 위함입니다.


<br />
<br />


> **처리한 에러 종류는 다음과 같습니다**

**1. 데이터 패칭 관련 에러**

Next api서버인 `router handler`에서 외부 백엔드 api로 요청을 하게 되면 status가 200으로 반환됩니다.

그렇기 때문에 fetch 반환값인`response.ok`가 아닌,  **반환된 데이터에서 이번 과제 요구사항중 하나였던 `OrgCourseListResponse` 타입으로 매핑하는 과정에서 에러가 발생하면 `{ status: 400 }` 응답을 컴포넌트로 반환하게끔 했습니다.**

이렇게 되면 최종적으로 클라이언트 컴포넌트,서버 컴포넌트에서 `router handler`로 요청을 보낸 뒤,
반환된 staus를 기반으로 에러를 구분짓고 `error.tsx`로 throw하게 됩니다

```tsx
                   throw                     throw
`router handler` ----------> 컴포넌트fetch ----------> `error.tsx`

```

<br />
<br />

**2. 필터링 쿼리스트링 유효성에 따른 에러**

URL값을 기반으로 필터링 조건을 생성하게 되는데, 필터링 조건을 생성하는 유틸 함수에서 만약 기존에 제가 정해놓은 
퀴리 키값들에 매칭되지 않는 값이 들어온다면  `error.tsx`로 throw하게 됩니다

![image](https://github.com/minh0518/elice-Frontend-PA/assets/78631876/906a6b44-c02f-47f1-af04-477bb19078a2)


<br />
<br />

**3. 존재하지 않는 페이지 진입**

Next의 `Catch-all` 라우트를 사용합니다. 메인페이지로 사용되는 URL이외의 페이지로 접근하게 되면
해당 에러 페이지를 띄웁니다.


<br/>

### 📷 스크린 샷 (선택)

<br/>

### 🗣 리뷰어한테 할 말 (선택)

<br/>

### 🧪 테스트 범위 (선택)
